### PR TITLE
ci: restore iOS e2e test

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -87,24 +87,26 @@ jobs:
           E2E_WALLET_SINGLE_VERIFIED_MNEMONIC: ${{ steps.google-secrets.outputs.E2E_WALLET_SINGLE_VERIFIED_MNEMONIC }}
           E2E_WALLET_MULTIPLE_VERIFIED_MNEMONIC: ${{ steps.google-secrets.outputs.E2E_WALLET_MULTIPLE_VERIFIED_MNEMONIC }}
           E2E_WALLET_12_WORDS_MNEMONIC: ${{ steps.google-secrets.outputs.E2E_WALLET_12_WORDS_MNEMONIC }}
-      - name: Publish iOS JUnit Report
-        if: always()
-        uses: mikepenz/action-junit-report@v4
-        with:
-          check_name: iOS (${{ inputs.ios-version }}) e2e Test Report
-          report_paths: 'e2e/test-results/junit.xml'
+      # Disabled for now, as the reports are sent to the wrong build
+      # See https://github.com/mikepenz/action-junit-report/issues/40
+      # - name: Publish iOS JUnit Report
+      #   if: always()
+      #   uses: mikepenz/action-junit-report@v4
+      #   with:
+      #     check_name: iOS (${{ inputs.ios-version }}) e2e Test Report
+      #     report_paths: 'e2e/test-results/junit.xml'
       - name: 'Upload iOS E2E Artifacts'
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: ios-${{ inputs.ios-version }}-e2e-artifact
-          path: e2e/artifacts
+          path: apps/example/e2e/artifacts
       - name: 'Upload iOS E2E HTML Report'
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: ios-${{ inputs.ios-version }}-test-report
-          path: e2e/test-results
+          path: apps/example/e2e/test-results
       - name: 'Close simulators'
         if: always()
         run: xcrun simctl shutdown all

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -38,6 +38,13 @@ jobs:
             E2E_WALLET_12_WORDS_MNEMONIC:projects/1027349420744/secrets/E2E_WALLET_12_WORDS_MNEMONIC
       - uses: actions/checkout@v4
       - uses: ./.github/actions/yarn-install
+      - name: Install Ruby dependencies
+        run: bundle install --path vendor/bundle
+      - name: Fail if someone forgot to commit "Gemfile.lock"
+        run: git diff --exit-code
+      # This way cocoapods and other installed gems from the Gemfile can be found without using `bundle exec`
+      - name: Add installed Gems binaries to PATH
+        run: echo "$(ruby -e 'puts Gem.bindir')" >> $GITHUB_PATH
       - name: Check E2E wallet balance
         run: NODE_OPTIONS='--unhandled-rejections=strict' yarn ts-node ./e2e/scripts/check-e2e-wallet-balance.ts
         working-directory: apps/example

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -54,18 +54,16 @@ jobs:
       - name: Create Detox Build
         run: yarn run e2e:build:ios-release
         working-directory: apps/example
-      # Disabled for now as we can currently only submit a limited number of builds
-      # and the script is relying on fastlane which we don't setup in this workflow anymore
-      # - name: Upload Detox Build to Emerge
-      #   if: |
-      #     env.SECRETS_AVAILABLE
-      #       && (github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group')
-      #   # This step is not critical, so we continue on error
-      #   continue-on-error: true
-      #   run: yarn ts-node .github/scripts/uploadE2eBuildToEmerge.ts
-      #   env:
-      #     EMERGE_API_TOKEN: ${{ steps.google-secrets.outputs.EMERGE_API_TOKEN }}
-      #     DETOX_CONFIG: ios.release
+      - name: Upload Detox Build to Emerge
+        if: |
+          env.SECRETS_AVAILABLE
+            && (github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group')
+        # This step is not critical, so we continue on error
+        continue-on-error: true
+        run: yarn ts-node .github/scripts/uploadE2eBuildToEmerge.ts
+        env:
+          EMERGE_API_TOKEN: ${{ steps.google-secrets.outputs.EMERGE_API_TOKEN }}
+          DETOX_CONFIG: ios.release
       - name: Run Detox
         run: >
           yarn detox test

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -8,8 +8,6 @@ on:
 
 jobs:
   ios:
-    # TODO re-enable once we have an app in the repo
-    if: false
     env:
       # `if` conditions can't directly access secrets, so we use a workaround
       # See https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow
@@ -40,36 +38,27 @@ jobs:
             E2E_WALLET_12_WORDS_MNEMONIC:projects/1027349420744/secrets/E2E_WALLET_12_WORDS_MNEMONIC
       - uses: actions/checkout@v4
       - uses: ./.github/actions/yarn-install
-      # Since the e2e runners have access to the Valora branding,
-      # This check ensures there are no type errors there.
-      # The `yarn build` step done in the test workflow also includes it but does it with the default celo branding.
-      - name: TS check
-        run: yarn build:ts
-      - name: Install Ruby dependencies
-        run: bundle install --path vendor/bundle
-      - name: Fail if someone forgot to commit "Gemfile.lock"
-        run: git diff --exit-code
-      - name: Install CocoaPods dependencies
-        working-directory: ios
-        run: bundle exec pod install || bundle exec pod install --repo-update
-      - name: Fail if someone forgot to commit "Podfile.lock" and push changes if PR is from renovate
-        run: yarn ts-node ./.github/scripts/checkPodfileAndUpdateRenovatePr.ts
       - name: Check E2E wallet balance
         run: NODE_OPTIONS='--unhandled-rejections=strict' yarn ts-node ./e2e/scripts/check-e2e-wallet-balance.ts
+        working-directory: apps/example
+      - name: Prebuild
+        run: yarn run prebuild
+        working-directory: apps/example
       - name: Create Detox Build
-        run: |
-          export CELO_TEST_CONFIG=e2e
-          yarn detox build -c ios.release
-      - name: Upload Detox Build to Emerge
-        if: |
-          env.SECRETS_AVAILABLE
-            && (github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group')
-        # This step is not critical, so we continue on error
-        continue-on-error: true
-        run: yarn ts-node .github/scripts/uploadE2eBuildToEmerge.ts
-        env:
-          EMERGE_API_TOKEN: ${{ steps.google-secrets.outputs.EMERGE_API_TOKEN }}
-          DETOX_CONFIG: ios.release
+        run: yarn run e2e:build:ios-release
+        working-directory: apps/example
+      # Disabled for now as we can currently only submit a limited number of builds
+      # and the script is relying on fastlane which we don't setup in this workflow anymore
+      # - name: Upload Detox Build to Emerge
+      #   if: |
+      #     env.SECRETS_AVAILABLE
+      #       && (github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group')
+      #   # This step is not critical, so we continue on error
+      #   continue-on-error: true
+      #   run: yarn ts-node .github/scripts/uploadE2eBuildToEmerge.ts
+      #   env:
+      #     EMERGE_API_TOKEN: ${{ steps.google-secrets.outputs.EMERGE_API_TOKEN }}
+      #     DETOX_CONFIG: ios.release
       - name: Run Detox
         run: >
           yarn detox test
@@ -82,6 +71,7 @@ jobs:
           --debug-synchronization 10000
           --maxWorkers 6
           --retries 3
+        working-directory: apps/example
         timeout-minutes: 45
         env:
           E2E_WALLET_CONNECT_PROJECT_ID: ${{ steps.google-secrets.outputs.E2E_WALLET_CONNECT_PROJECT_ID }}

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -43,7 +43,7 @@ jobs:
       max-parallel: 2
       fail-fast: false
       matrix:
-        # 15.1 is not included as it runs on the merge queue
+        # 15.2 is not included as it runs on the merge queue
         ios-version: ['17.2']
     uses: ./.github/workflows/e2e-ios.yml
     with:

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -43,7 +43,7 @@ jobs:
       max-parallel: 2
       fail-fast: false
       matrix:
-        # 15.0 is not included as it runs on the merge queue
+        # 15.1 is not included as it runs on the merge queue
         ios-version: ['17.2']
     uses: ./.github/workflows/e2e-ios.yml
     with:

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -23,5 +23,5 @@ jobs:
     name: iOS
     uses: ./.github/workflows/e2e-ios.yml
     with:
-      ios-version: '15.1'
+      ios-version: '15.2'
     secrets: inherit

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -2,8 +2,8 @@ name: E2E - PR
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
+    # branches:
+    #   - main
   merge_group:
 
 # Cancel any in progress run of the workflow for a given PR

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -2,8 +2,8 @@ name: E2E - PR
 on:
   workflow_dispatch:
   pull_request:
-    # branches:
-    #   - main
+    branches:
+      - main
   merge_group:
 
 # Cancel any in progress run of the workflow for a given PR

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -23,5 +23,5 @@ jobs:
     name: iOS
     uses: ./.github/workflows/e2e-ios.yml
     with:
-      ios-version: '15.0'
+      ios-version: '15.1'
     secrets: inherit

--- a/apps/example/app.json
+++ b/apps/example/app.json
@@ -48,6 +48,8 @@
         "expo-build-properties",
         {
           "ios": {
+            // Minimum iOS version we support
+            "deploymentTarget": "15.1",
             "useFrameworks": "static"
           },
           "android": {

--- a/apps/example/app.json
+++ b/apps/example/app.json
@@ -2,6 +2,8 @@
   "expo": {
     "name": "MobileStack",
     "slug": "mobile-stack",
+    // TODO: use a MobileStack scheme
+    "scheme": "celo",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/apps/example/detox.config.js
+++ b/apps/example/detox.config.js
@@ -42,11 +42,11 @@ module.exports = {
         type: 'iPhone SE (2nd generation)',
       },
     },
-    'simulator.15.1': {
+    'simulator.15.2': {
       type: 'ios.simulator',
       device: {
         type: 'iPhone SE (2nd generation)',
-        os: 'iOS 15.1',
+        os: 'iOS 15.2',
       },
     },
     'simulator.17.2': {
@@ -73,8 +73,8 @@ module.exports = {
       device: 'simulator',
       app: 'ios.release',
     },
-    'ios.release.15.1': {
-      device: 'simulator.15.1',
+    'ios.release.15.2': {
+      device: 'simulator.15.2',
       app: 'ios.release',
     },
     'ios.release.17.2': {

--- a/apps/example/detox.config.js
+++ b/apps/example/detox.config.js
@@ -42,11 +42,11 @@ module.exports = {
         type: 'iPhone SE (2nd generation)',
       },
     },
-    'simulator.15.0': {
+    'simulator.15.1': {
       type: 'ios.simulator',
       device: {
         type: 'iPhone SE (2nd generation)',
-        os: 'iOS 15.0',
+        os: 'iOS 15.1',
       },
     },
     'simulator.17.2': {
@@ -73,8 +73,8 @@ module.exports = {
       device: 'simulator',
       app: 'ios.release',
     },
-    'ios.release.15.0': {
-      device: 'simulator.15.0',
+    'ios.release.15.1': {
+      device: 'simulator.15.1',
       app: 'ios.release',
     },
     'ios.release.17.2': {

--- a/apps/example/e2e/src/Notifications.spec.js
+++ b/apps/example/e2e/src/Notifications.spec.js
@@ -1,7 +1,8 @@
 import HandleNotification from './usecases/HandleNotification'
 import { quickOnboarding } from './utils/utils'
 
-describe('Handle app open from push notifications', () => {
+// TODO: re-enable once we add back CleverTap, since it's required for this test
+describe.skip('Handle app open from push notifications', () => {
   beforeAll(async () => {
     await quickOnboarding()
   })

--- a/apps/example/e2e/src/usecases/DappListDisplay.js
+++ b/apps/example/e2e/src/usecases/DappListDisplay.js
@@ -31,7 +31,8 @@ export default DappListDisplay = () => {
     await element(by.id('WebViewScreen/CloseButton')).tap()
   })
 
-  it(':ios: should correctly filter dapp list based on user agent', async () => {
+  // TODO: re-enable once we have the UserAgent module in the example app
+  it.skip(':ios: should correctly filter dapp list based on user agent', async () => {
     const iOSDappList = await fetchDappList('Valora/1.0.0 (iOS 15.0; iPhone)')
     const dappCards = await getElementTextList('DappsScreen/AllSection/DappCard')
     jestExpect(dappCards.length).toEqual(iOSDappList.applications.length)


### PR DESCRIPTION
### Description

The iOS e2e test now works for the example app.

One thing I noticed is building the iOS app for detox takes longer: it's now **~7 mins** and previously it was around **~3:30 mins** ([example](https://github.com/valora-inc/wallet/actions/runs/12764358461/job/35576389738)).

I'm not sure if it's because there are a few more native modules to build with expo or if it's something else.
For instance because the project is re-generated during the workflow, maybe we don't get as much caching from Xcode compared to what we had previously.

We could try to enable ccache though to see if it'd help: 
https://docs.expo.dev/versions/latest/sdk/build-properties/#:~:text=Description-,ccacheEnabled,-(optional)

It could also be explained by the new RN version used to build.

Or a combination of all of these.

Part of RET-1279
