### PR TITLE
feat(ios): add config plugin to reset keychain on first launch

### DIFF
--- a/packages/runtime/plugin/src/index.ts
+++ b/packages/runtime/plugin/src/index.ts
@@ -1,12 +1,16 @@
 import { ConfigPlugin, withPlugins } from '@expo/config-plugins'
 
 import { withAndroidCameraBuildFix } from './withAndroidCameraBuildFix'
+import { withIosAppDelegateResetKeychain } from './withIosAppDelegateResetKeychain'
 
 /**
  * A config plugin for configuring `@mobilestack-xyz/runtime`
  */
 const withMobileStackApp: ConfigPlugin = (config) => {
   return withPlugins(config, [
+    // iOS
+    withIosAppDelegateResetKeychain,
+
     // Android
     withAndroidCameraBuildFix,
   ])

--- a/packages/runtime/plugin/src/withIosAppDelegateResetKeychain.ts
+++ b/packages/runtime/plugin/src/withIosAppDelegateResetKeychain.ts
@@ -38,8 +38,6 @@ const INVOCATION_LINE_MATCHER =
   /-\s*\(BOOL\)\s*application:\s*\(UIApplication\s*\*\s*\)\s*\w+\s+didFinishLaunchingWithOptions:/g
 
 function addResetKeychainFunction(src: string): MergeResults {
-  const newSrc = ['#if canImport(GoogleMaps)', 'import GoogleMaps', '#endif']
-
   return mergeContents({
     tag: '@mobilestack-xyz/runtime/app-delegate-reset-keychain-function',
     src,

--- a/packages/runtime/plugin/src/withIosAppDelegateResetKeychain.ts
+++ b/packages/runtime/plugin/src/withIosAppDelegateResetKeychain.ts
@@ -1,0 +1,91 @@
+// Inspired by https://github.com/expo/expo/blob/03e99016c9c5b9ad47864b204511ded2dec80375/packages/%40expo/config-plugins/src/ios/Maps.ts#L6
+import { ConfigPlugin, withAppDelegate } from '@expo/config-plugins'
+import { mergeContents, MergeResults } from '@expo/config-plugins/build/utils/generateCode'
+
+const RESET_KEYCHAIN_FUNCTION = `
+// Use same key as react-native-secure-key-store
+// so we don't reset already working installs
+static NSString * const kHasRunBeforeKey = @"RnSksIsAppInstalled";
+
+// Reset keychain on first app run, this is so we don't run with leftover items
+// after reinstalling the app
+static void resetKeychainIfNecessary()
+{
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  if ([defaults boolForKey:kHasRunBeforeKey]) {
+    return;
+  }
+  
+  NSArray *secItemClasses = @[(__bridge id)kSecClassGenericPassword,
+                              (__bridge id)kSecAttrGeneric,
+                              (__bridge id)kSecAttrAccount,
+                              (__bridge id)kSecClassKey,
+                              (__bridge id)kSecAttrService];
+  for (id secItemClass in secItemClasses) {
+    NSDictionary *spec = @{(__bridge id)kSecClass:secItemClass};
+    SecItemDelete((__bridge CFDictionaryRef)spec);
+  }
+  
+  [defaults setBool:YES forKey:kHasRunBeforeKey];
+  [defaults synchronize];
+}
+`
+
+const METHOD_INVOCATION_BLOCK = `resetKeychainIfNecessary();`
+
+// https://regex101.com/r/nHrTa9/1/
+const INVOCATION_LINE_MATCHER =
+  /-\s*\(BOOL\)\s*application:\s*\(UIApplication\s*\*\s*\)\s*\w+\s+didFinishLaunchingWithOptions:/g
+
+function addResetKeychainFunction(src: string): MergeResults {
+  const newSrc = ['#if canImport(GoogleMaps)', 'import GoogleMaps', '#endif']
+
+  return mergeContents({
+    tag: '@mobilestack-xyz/runtime/app-delegate-reset-keychain-function',
+    src,
+    newSrc: RESET_KEYCHAIN_FUNCTION,
+    anchor: /@implementation AppDelegate/,
+    offset: -1,
+    comment: '//',
+  })
+}
+
+function addCallResetKeychain(src: string): MergeResults {
+  // tests if the opening `{` is in the new line
+  const multilineMatcher = new RegExp(INVOCATION_LINE_MATCHER.source + '.+\\n*{')
+  const isHeaderMultiline = multilineMatcher.test(src)
+
+  return mergeContents({
+    tag: '@mobilestack-xyz/runtime/app-delegate-call-reset-keychain',
+    src,
+    newSrc: METHOD_INVOCATION_BLOCK,
+    anchor: INVOCATION_LINE_MATCHER,
+    // new line will be inserted right below matched anchor
+    // or two lines, if the `{` is in the new line
+    offset: isHeaderMultiline ? 2 : 1,
+    comment: '//',
+  })
+}
+
+export const withIosAppDelegateResetKeychain: ConfigPlugin = (config) => {
+  return withAppDelegate(config, (config) => {
+    if (!['objc', 'objcpp'].includes(config.modResults.language)) {
+      throw new Error(
+        `Cannot setup MobileStack runtime because the project AppDelegate is not a supported language: ${config.modResults.language}`
+      )
+    }
+
+    try {
+      config.modResults.contents = addResetKeychainFunction(config.modResults.contents).contents
+      config.modResults.contents = addCallResetKeychain(config.modResults.contents).contents
+    } catch (error: any) {
+      if (error.code === 'ERR_NO_MATCH') {
+        throw new Error(
+          `Cannot add MobileStack runtime to the project's AppDelegate because it's malformed. Please report this with a copy of your project AppDelegate.`
+        )
+      }
+      throw error
+    }
+    return config
+  })
+}

--- a/packages/runtime/plugin/tsconfig.json
+++ b/packages/runtime/plugin/tsconfig.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "build",
     "rootDir": "src",
-    "declaration": true
+    "declaration": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strictNullChecks": true,
   },
   "include": ["./src"]
 }

--- a/packages/runtime/plugin/tsconfig.json
+++ b/packages/runtime/plugin/tsconfig.json
@@ -7,7 +7,7 @@
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "strictNullChecks": true,
+    "strictNullChecks": true
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
### Description

As I was working to re-enable iOS e2e tests (https://github.com/mobilestack-xyz/mobilestack/pull/8), this appeared to be needed to successfully run them.
Otherwise they'd remain stuck on the account reset screen, due to the leftover state in the keychain.

Part of RET-1282