### PR TITLE
feat: add config plugin to set app-wide User-Agent

### DIFF
--- a/apps/example/e2e/src/usecases/DappListDisplay.js
+++ b/apps/example/e2e/src/usecases/DappListDisplay.js
@@ -31,8 +31,7 @@ export default DappListDisplay = () => {
     await element(by.id('WebViewScreen/CloseButton')).tap()
   })
 
-  // TODO: re-enable once we have the UserAgent module in the example app
-  it.skip(':ios: should correctly filter dapp list based on user agent', async () => {
+  it(':ios: should correctly filter dapp list based on user agent', async () => {
     const iOSDappList = await fetchDappList('Valora/1.0.0 (iOS 15.0; iPhone)')
     const dappCards = await getElementTextList('DappsScreen/AllSection/DappCard')
     jestExpect(dappCards.length).toEqual(iOSDappList.applications.length)

--- a/packages/runtime/plugin/src/consts.ts
+++ b/packages/runtime/plugin/src/consts.ts
@@ -1,0 +1,7 @@
+// https://regex101.com/r/nHrTa9/1/
+export const APPLICATION_DID_FINISH_LAUNCHING_LINE_MATCHER =
+  /-\s*\(BOOL\)\s*application:\s*\(UIApplication\s*\*\s*\)\s*\w+\s+didFinishLaunchingWithOptions:/g
+
+export const APPLICATION_DID_FINISH_LAUNCHING_LINE_MATCHER_MULTILINE = new RegExp(
+  APPLICATION_DID_FINISH_LAUNCHING_LINE_MATCHER.source + '.+\\n*{'
+)

--- a/packages/runtime/plugin/src/index.ts
+++ b/packages/runtime/plugin/src/index.ts
@@ -1,18 +1,22 @@
 import { ConfigPlugin, withPlugins } from '@expo/config-plugins'
 
 import { withAndroidCameraBuildFix } from './withAndroidCameraBuildFix'
+import { withAndroidUserAgent } from './withAndroidUserAgent'
 import { withIosAppDelegateResetKeychain } from './withIosAppDelegateResetKeychain'
+import { withIosUserAgent } from './withIosUserAgent'
 
 /**
  * A config plugin for configuring `@mobilestack-xyz/runtime`
  */
-const withMobileStackApp: ConfigPlugin = (config) => {
+const withMobileStackApp: ConfigPlugin<{ appName?: string }> = (config, props = {}) => {
   return withPlugins(config, [
     // iOS
     withIosAppDelegateResetKeychain,
+    [withIosUserAgent, props],
 
     // Android
     withAndroidCameraBuildFix,
+    [withAndroidUserAgent, props],
   ])
 }
 

--- a/packages/runtime/plugin/src/withAndroidUserAgent.ts
+++ b/packages/runtime/plugin/src/withAndroidUserAgent.ts
@@ -1,0 +1,95 @@
+// Inspired by https://github.com/expo/expo/blob/03e99016c9c5b9ad47864b204511ded2dec80375/packages/%40expo/config-plugins/src/ios/Maps.ts#L6
+import { ConfigPlugin, withMainApplication } from '@expo/config-plugins'
+import { mergeContents, MergeResults } from '@expo/config-plugins/build/utils/generateCode'
+
+const NEEDED_IMPORTS = [
+  'import android.os.Build',
+  'import com.facebook.react.modules.network.OkHttpClientFactory',
+  'import com.facebook.react.modules.network.OkHttpClientProvider',
+  'import okhttp3.OkHttpClient',
+  'import okhttp3.Interceptor',
+  'import okhttp3.Request',
+  'import okhttp3.Response',
+]
+
+function getUserAgentCode(appName: string) {
+  return `
+OkHttpClientProvider.setOkHttpClientFactory(object : OkHttpClientFactory {
+    override fun createNewNetworkModuleClient(): OkHttpClient {
+        return OkHttpClientProvider.createClientBuilder(this@MainApplication)
+            .addInterceptor(Interceptor { chain ->
+                val originalRequest = chain.request()
+                val requestWithUserAgent = originalRequest
+                    .newBuilder()
+                    .removeHeader("User-Agent")
+                    .addHeader(
+                        "User-Agent",
+                        "${appName}/%s (Android %s; %s)".format(
+                            BuildConfig.VERSION_NAME,
+                            Build.VERSION.RELEASE,
+                            Build.MODEL
+                        )
+                    )
+                    .build()
+                chain.proceed(requestWithUserAgent)
+            })
+            .build()
+    }
+})
+`
+}
+
+function addNeededImports(src: string): MergeResults {
+  // filter out imports that are already present
+  const imports = NEEDED_IMPORTS.filter((imp) => !src.includes(imp))
+
+  return mergeContents({
+    tag: '@mobilestack-xyz/runtime/main-application-user-agent-imports',
+    src,
+    newSrc: imports.join('\n'),
+    anchor: /import com\.facebook\.soloader\.SoLoader/,
+    offset: 1,
+    comment: '//',
+  })
+}
+
+function addUserAgentCode(src: string, appName: string): MergeResults {
+  return mergeContents({
+    tag: '@mobilestack-xyz/runtime/main-application-user-agent-code',
+    src,
+    newSrc: getUserAgentCode(appName),
+    anchor: /ApplicationLifecycleDispatcher\.onApplicationCreate\(this\)/,
+    offset: 0,
+    comment: '//',
+  })
+}
+
+/**
+ * Config plugin for setting an app-wide User-Agent header for all requests
+ * TODO: consider shipping this as a react native module
+ */
+export const withAndroidUserAgent: ConfigPlugin<{ appName?: string }> = (config, { appName }) => {
+  return withMainApplication(config, (config) => {
+    if (!['kt'].includes(config.modResults.language)) {
+      throw new Error(
+        `Cannot setup MobileStack runtime because the project MainApplication is not a supported language: ${config.modResults.language}`
+      )
+    }
+
+    try {
+      config.modResults.contents = addNeededImports(config.modResults.contents).contents
+      config.modResults.contents = addUserAgentCode(
+        config.modResults.contents,
+        appName ?? config.name
+      ).contents
+    } catch (error: any) {
+      if (error.code === 'ERR_NO_MATCH') {
+        throw new Error(
+          `Cannot add MobileStack runtime to the project's MainApplication because it's malformed. Please report this with a copy of your project MainApplication.`
+        )
+      }
+      throw error
+    }
+    return config
+  })
+}

--- a/packages/runtime/plugin/src/withIosAppDelegateResetKeychain.ts
+++ b/packages/runtime/plugin/src/withIosAppDelegateResetKeychain.ts
@@ -1,6 +1,7 @@
 // Inspired by https://github.com/expo/expo/blob/03e99016c9c5b9ad47864b204511ded2dec80375/packages/%40expo/config-plugins/src/ios/Maps.ts#L6
 import { ConfigPlugin, withAppDelegate } from '@expo/config-plugins'
 import { mergeContents, MergeResults } from '@expo/config-plugins/build/utils/generateCode'
+import { APPLICATION_DID_FINISH_LAUNCHING_LINE_MATCHER, APPLICATION_DID_FINISH_LAUNCHING_LINE_MATCHER_MULTILINE } from './consts'
 
 const RESET_KEYCHAIN_FUNCTION = `
 // Use same key as react-native-secure-key-store
@@ -33,10 +34,6 @@ static void resetKeychainIfNecessary()
 
 const METHOD_INVOCATION_BLOCK = `resetKeychainIfNecessary();`
 
-// https://regex101.com/r/nHrTa9/1/
-const INVOCATION_LINE_MATCHER =
-  /-\s*\(BOOL\)\s*application:\s*\(UIApplication\s*\*\s*\)\s*\w+\s+didFinishLaunchingWithOptions:/g
-
 function addResetKeychainFunction(src: string): MergeResults {
   return mergeContents({
     tag: '@mobilestack-xyz/runtime/app-delegate-reset-keychain-function',
@@ -50,14 +47,13 @@ function addResetKeychainFunction(src: string): MergeResults {
 
 function addCallResetKeychain(src: string): MergeResults {
   // tests if the opening `{` is in the new line
-  const multilineMatcher = new RegExp(INVOCATION_LINE_MATCHER.source + '.+\\n*{')
-  const isHeaderMultiline = multilineMatcher.test(src)
+  const isHeaderMultiline = APPLICATION_DID_FINISH_LAUNCHING_LINE_MATCHER_MULTILINE.test(src)
 
   return mergeContents({
     tag: '@mobilestack-xyz/runtime/app-delegate-call-reset-keychain',
     src,
     newSrc: METHOD_INVOCATION_BLOCK,
-    anchor: INVOCATION_LINE_MATCHER,
+    anchor: APPLICATION_DID_FINISH_LAUNCHING_LINE_MATCHER,
     // new line will be inserted right below matched anchor
     // or two lines, if the `{` is in the new line
     offset: isHeaderMultiline ? 2 : 1,

--- a/packages/runtime/plugin/src/withIosAppDelegateResetKeychain.ts
+++ b/packages/runtime/plugin/src/withIosAppDelegateResetKeychain.ts
@@ -1,7 +1,10 @@
 // Inspired by https://github.com/expo/expo/blob/03e99016c9c5b9ad47864b204511ded2dec80375/packages/%40expo/config-plugins/src/ios/Maps.ts#L6
 import { ConfigPlugin, withAppDelegate } from '@expo/config-plugins'
 import { mergeContents, MergeResults } from '@expo/config-plugins/build/utils/generateCode'
-import { APPLICATION_DID_FINISH_LAUNCHING_LINE_MATCHER, APPLICATION_DID_FINISH_LAUNCHING_LINE_MATCHER_MULTILINE } from './consts'
+import {
+  APPLICATION_DID_FINISH_LAUNCHING_LINE_MATCHER,
+  APPLICATION_DID_FINISH_LAUNCHING_LINE_MATCHER_MULTILINE,
+} from './consts'
 
 const RESET_KEYCHAIN_FUNCTION = `
 // Use same key as react-native-secure-key-store

--- a/packages/runtime/plugin/src/withIosUserAgent.ts
+++ b/packages/runtime/plugin/src/withIosUserAgent.ts
@@ -1,7 +1,10 @@
 // Inspired by https://github.com/expo/expo/blob/03e99016c9c5b9ad47864b204511ded2dec80375/packages/%40expo/config-plugins/src/ios/Maps.ts#L6
 import { ConfigPlugin, withAppDelegate } from '@expo/config-plugins'
 import { mergeContents, MergeResults } from '@expo/config-plugins/build/utils/generateCode'
-import { APPLICATION_DID_FINISH_LAUNCHING_LINE_MATCHER, APPLICATION_DID_FINISH_LAUNCHING_LINE_MATCHER_MULTILINE } from './consts'
+import {
+  APPLICATION_DID_FINISH_LAUNCHING_LINE_MATCHER,
+  APPLICATION_DID_FINISH_LAUNCHING_LINE_MATCHER_MULTILINE,
+} from './consts'
 
 function getUserAgentCode(appName: string) {
   return `

--- a/packages/runtime/plugin/src/withIosUserAgent.ts
+++ b/packages/runtime/plugin/src/withIosUserAgent.ts
@@ -1,0 +1,66 @@
+// Inspired by https://github.com/expo/expo/blob/03e99016c9c5b9ad47864b204511ded2dec80375/packages/%40expo/config-plugins/src/ios/Maps.ts#L6
+import { ConfigPlugin, withAppDelegate } from '@expo/config-plugins'
+import { mergeContents, MergeResults } from '@expo/config-plugins/build/utils/generateCode'
+import { APPLICATION_DID_FINISH_LAUNCHING_LINE_MATCHER, APPLICATION_DID_FINISH_LAUNCHING_LINE_MATCHER_MULTILINE } from './consts'
+
+function getUserAgentCode(appName: string) {
+  return `
+RCTSetCustomNSURLSessionConfigurationProvider(^NSURLSessionConfiguration *{
+    NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+    
+    NSDictionary *infoDictionary = NSBundle.mainBundle.infoDictionary;
+    NSString *appVersion = [infoDictionary objectForKey:@"CFBundleShortVersionString"];
+    UIDevice *device = UIDevice.currentDevice;
+    // Format we want: App/1.0.0 (iOS 15.0; iPhone)
+    NSString *userAgent = [NSString stringWithFormat:@"${appName}/%@ (%@ %@; %@)", appVersion, device.systemName, device.systemVersion, device.model];
+    configuration.HTTPAdditionalHeaders = @{ @"User-Agent": userAgent };
+    
+    return configuration;
+  });
+`
+}
+
+function addUserAgentCode(src: string, appName: string): MergeResults {
+  // tests if the opening `{` is in the new line
+  const isHeaderMultiline = APPLICATION_DID_FINISH_LAUNCHING_LINE_MATCHER_MULTILINE.test(src)
+
+  return mergeContents({
+    tag: '@mobilestack-xyz/runtime/app-delegate-user-agent-code',
+    src,
+    newSrc: getUserAgentCode(appName),
+    anchor: APPLICATION_DID_FINISH_LAUNCHING_LINE_MATCHER,
+    // new line will be inserted right below matched anchor
+    // or two lines, if the `{` is in the new line
+    offset: isHeaderMultiline ? 2 : 1,
+    comment: '//',
+  })
+}
+
+/**
+ * Config plugin for setting an app-wide User-Agent header for all requests
+ * TODO: consider shipping this as a react native module
+ */
+export const withIosUserAgent: ConfigPlugin<{ appName?: string }> = (config, { appName }) => {
+  return withAppDelegate(config, (config) => {
+    if (!['objc', 'objcpp'].includes(config.modResults.language)) {
+      throw new Error(
+        `Cannot setup MobileStack runtime because the project AppDelegate is not a supported language: ${config.modResults.language}`
+      )
+    }
+
+    try {
+      config.modResults.contents = addUserAgentCode(
+        config.modResults.contents,
+        appName ?? config.name
+      ).contents
+    } catch (error: any) {
+      if (error.code === 'ERR_NO_MATCH') {
+        throw new Error(
+          `Cannot add MobileStack runtime to the project's AppDelegate because it's malformed. Please report this with a copy of your project AppDelegate.`
+        )
+      }
+      throw error
+    }
+    return config
+  })
+}


### PR DESCRIPTION
### Description

Set our app-wide User-Agent by using a config plugin.

I think later it could be nice to publish this as its own React Native lib. But for now this is good enough.

Part of RET-1282
