### PR TITLE
feat: allow customizing welcome screen

### DIFF
--- a/packages/runtime/src/onboarding/welcome/Welcome.tsx
+++ b/packages/runtime/src/onboarding/welcome/Welcome.tsx
@@ -14,6 +14,7 @@ import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import LanguageButton from 'src/onboarding/LanguageButton'
 import { firstOnboardingScreen } from 'src/onboarding/steps'
+import { getAppConfig } from 'src/public/appConfig'
 import { useDispatch, useSelector } from 'src/redux/hooks'
 import { patchUpdateStatsigUser } from 'src/statsig'
 import { Spacing } from 'src/styles/styles'
@@ -61,11 +62,28 @@ export default function Welcome() {
     navigateNext()
   }
 
+  const config = getAppConfig()
+  const welcomeConfig = config.screens?.welcome ?? {}
+
+  const CustomWelcomeComponent = 'component' in welcomeConfig ? welcomeConfig.component : undefined
+  if (CustomWelcomeComponent) {
+    return (
+      <CustomWelcomeComponent
+        onPressCreateAccount={onPressCreateAccount}
+        onPressRestoreAccount={onPressRestoreAccount}
+      />
+    )
+  }
+
+  const Logo = 'logo' in welcomeConfig && welcomeConfig.logo ? welcomeConfig.logo : WelcomeLogo
+  const backgroundImage =
+    'backgroundImage' in welcomeConfig ? welcomeConfig.backgroundImage : welcomeBackground
+
   return (
     <SafeAreaView style={styles.container}>
-      <ImageBackground source={welcomeBackground} resizeMode="stretch" style={styles.image}>
+      <ImageBackground source={backgroundImage} resizeMode="stretch" style={styles.image}>
         <View style={styles.contentContainer}>
-          <WelcomeLogo />
+          <Logo />
         </View>
         <View style={{ ...styles.buttonView, marginBottom: Math.max(0, 40 - insets.bottom) }}>
           <Button

--- a/packages/runtime/src/public/types.tsx
+++ b/packages/runtime/src/public/types.tsx
@@ -56,6 +56,20 @@ export interface PublicAppConfig<tabScreenConfigs extends TabScreenConfig[] = Ta
 
   // Screen overrides
   screens?: {
+    // Onboarding welcome screen
+    welcome?:
+      | {
+          // Customize some parts
+          logo?: React.ComponentType<any>
+          backgroundImage?: typeof require
+        }
+      | {
+          // Or provide the entire component
+          component?: React.ComponentType<{
+            onPressCreateAccount: () => void
+            onPressRestoreAccount: () => void
+          }>
+        }
     // Tab navigation configuration
     tabs?: (args: {
       defaultTabs: {


### PR DESCRIPTION
### Description

This is a proposal to allow customizing the onboarding welcome screen.
I'm not yet sure we really need/want the full component customization (Example 2)
Probably we should start with 1 and add 2 later on if needed.

```tsx
// Example 1: Customizing specific parts of the default welcome screen
const App = createApp({
  // ... other config
  screens: {
    welcome: {
      // Custom logo component
      logo: CustomLogoComponent,
      // Background image using require
      backgroundImage: require('../assets/welcome-bg.png'),
    }
  }
})

// Example 2: Providing a completely custom welcome screen component
const App = createApp({
  // ... other config
  screens: {
    welcome: {
      // Well, in reality we would likely not define it inline, but this is just an example
      component: ({ onPressCreateAccount, onPressRestoreAccount }) => {
        return (
          <View>
            <Text>Welcome to My Custom Screen!</Text>
            <Button 
              title="Create New Account" 
              onPress={onPressCreateAccount} 
            />
            <Button 
              title="Restore Existing Account" 
              onPress={onPressRestoreAccount} 
            />
          </View>
        )
      }
    }
  }
})
```
